### PR TITLE
HEAD, OPTIONS, DELETE

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -41,7 +41,7 @@ function bodyObjectCheck(req, res, next) {
   }
 }
 
-function genericHead(req, res, next) {
+function genericHEAD(req, res, next) {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
     res.status(200)
     .set({
@@ -54,9 +54,17 @@ function genericHead(req, res, next) {
   }
 }
 
+function genericOPTIONS(req, res) {
+  res.status(200)
+  .set({
+    Allow: res.locals.methodsString,
+  })
+  .end();
+}
+
 app.all('/api/v1', (req, res, next) => {
-  res.locals.methods = ['HEAD', 'GET'];
-  res.locals.methodsString = res.locals.methods.join(', ');
+  res.locals.methods = ['HEAD', 'OPTIONS', 'GET'];
+  res.locals.methodsString = res.locals.methods.join(' ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
   } else {
@@ -64,7 +72,9 @@ app.all('/api/v1', (req, res, next) => {
   }
 });
 
-app.head('/api/v1', genericHead);
+app.head('/api/v1', genericHEAD);
+
+app.options('/api/v1', genericOPTIONS);
 
 app.get('/api/v1', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -89,8 +99,8 @@ app.get('/api/v1', (req, res, next) => {
 });
 
 app.all('/api/v1/users', (req, res, next) => {
-  res.locals.methods = ['HEAD', 'GET', 'POST'];
-  res.locals.methodsString = res.locals.methods.join(', ');
+  res.locals.methods = ['HEAD', 'OPTIONS', 'GET', 'POST'];
+  res.locals.methodsString = res.locals.methods.join(' ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
   } else {
@@ -98,7 +108,9 @@ app.all('/api/v1/users', (req, res, next) => {
   }
 });
 
-app.head('/api/v1/users', genericHead);
+app.head('/api/v1/users', genericHEAD);
+
+app.options('/api/v1/users', genericOPTIONS);
 
 app.get('/api/v1/users', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -148,8 +160,8 @@ app.post('/api/v1/users', reqMediaCheck, jsonParser, (req, res, next) => {
 });
 
 app.all('/api/v1/users/:name', (req, res, next) => {
-  res.locals.methods = ['HEAD', 'GET', 'PUT', 'DELETE'];
-  res.locals.methodsString = res.locals.methods.join(', ');
+  res.locals.methods = ['HEAD', 'OPTIONS', 'GET', 'PUT', 'DELETE'];
+  res.locals.methodsString = res.locals.methods.join(' ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
   } else {
@@ -168,7 +180,9 @@ app.use('/api/v1/users/:name', (req, res, next) => {
   });
 });
 
-app.head('/api/v1/users/:name', genericHead);
+app.head('/api/v1/users/:name', genericHEAD);
+
+app.options('/api/v1/users/:name', genericOPTIONS);
 
 app.get('/api/v1/users/:name', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -230,8 +244,8 @@ app.put('/api/v1/users/:name', (req, res) => {
 });
 
 app.all('/api/v1/messages', (req, res, next) => {
-  res.locals.methods = ['HEAD', 'GET', 'POST'];
-  res.locals.methodsString = res.locals.methods.join(', ');
+  res.locals.methods = ['HEAD', 'OPTIONS', 'GET', 'POST'];
+  res.locals.methodsString = res.locals.methods.join(' ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
   } else {
@@ -239,7 +253,9 @@ app.all('/api/v1/messages', (req, res, next) => {
   }
 });
 
-app.head('/api/v1/messages', genericHead);
+app.head('/api/v1/messages', genericHEAD);
+
+app.options('/api/v1/messages', genericOPTIONS);
 
 app.get('/api/v1/messages', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -297,8 +313,8 @@ app.post('/api/v1/messages', reqMediaCheck, jsonParser, (req, res, next) => {
 });
 
 app.all('/api/v1/messages/:ref_id', (req, res, next) => {
-  res.locals.methods = ['HEAD', 'GET', 'PUT', 'DELETE'];
-  res.locals.methodsString = res.locals.methods.join(', ');
+  res.locals.methods = ['HEAD', 'OPTIONS', 'GET', 'PUT', 'DELETE'];
+  res.locals.methodsString = res.locals.methods.join(' ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
   } else {
@@ -317,7 +333,9 @@ app.use('/api/v1/messages/:ref_id', (req, res, next) => {
   });
 });
 
-app.head('/api/v1/messages/:ref_id', genericHead);
+app.head('/api/v1/messages/:ref_id', genericHEAD);
+
+app.options('/api/v1/messages/:ref_id', genericOPTIONS);
 
 app.get('/api/v1/messages/:ref_id', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -408,8 +426,8 @@ app.put('/api/v1/messages/:ref_id', (req, res) => {
 });
 
 app.all('/api/v1/logs', (req, res, next) => {
-  res.locals.methods = ['HEAD', 'GET', 'POST'];
-  res.locals.methodsString = res.locals.methods.join(', ');
+  res.locals.methods = ['HEAD', 'OPTIONS', 'GET', 'POST'];
+  res.locals.methodsString = res.locals.methods.join(' ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
   } else {
@@ -417,7 +435,9 @@ app.all('/api/v1/logs', (req, res, next) => {
   }
 });
 
-app.head('/api/v1/logs', genericHead);
+app.head('/api/v1/logs', genericHEAD);
+
+app.options('/api/v1/logs', genericOPTIONS);
 
 app.get('/api/v1/logs', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -493,8 +513,8 @@ app.post('/api/v1/logs', reqMediaCheck, jsonParser, (req, res, next) => {
 });
 
 app.all('/api/v1/logs/:name', (req, res, next) => {
-  res.locals.methods = ['HEAD', 'GET', 'PUT', 'DELETE'];
-  res.locals.methodsString = res.locals.methods.join(', ');
+  res.locals.methods = ['HEAD', 'OPTIONS', 'GET', 'PUT', 'DELETE'];
+  res.locals.methodsString = res.locals.methods.join(' ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
   } else {
@@ -513,7 +533,9 @@ app.use('/api/v1/logs/:name', (req, res, next) => {
   });
 });
 
-app.head('/api/v1/logs/:name', genericHead);
+app.head('/api/v1/logs/:name', genericHEAD);
+
+app.options('/api/v1/logs/:name', genericOPTIONS);
 
 app.get('/api/v1/logs/:name', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {

--- a/src/api.js
+++ b/src/api.js
@@ -184,6 +184,17 @@ app.head('/api/v1/users/:name', genericHEAD);
 
 app.options('/api/v1/users/:name', genericOPTIONS);
 
+app.delete('/api/v1/users/:name', (req, res, next) => {
+  db.deleteUser(res.locals.user._id, (err) => {
+    if (err) {
+      customError(500, res.locals.methodsString, next);
+    } else {
+      res.status(204)
+      .end();
+    }
+  });
+});
+
 app.get('/api/v1/users/:name', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
     db.getMessages((err2, messages) => {
@@ -336,6 +347,17 @@ app.use('/api/v1/messages/:ref_id', (req, res, next) => {
 app.head('/api/v1/messages/:ref_id', genericHEAD);
 
 app.options('/api/v1/messages/:ref_id', genericOPTIONS);
+
+app.delete('/api/v1/messages/:ref_id', (req, res, next) => {
+  db.deleteMessage(res.locals.message._id, (err) => {
+    if (err) {
+      customError(500, res.locals.methodsString, next);
+    } else {
+      res.status(204)
+      .end();
+    }
+  });
+});
 
 app.get('/api/v1/messages/:ref_id', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -536,6 +558,17 @@ app.use('/api/v1/logs/:name', (req, res, next) => {
 app.head('/api/v1/logs/:name', genericHEAD);
 
 app.options('/api/v1/logs/:name', genericOPTIONS);
+
+app.delete('/api/v1/logs/:name', (req, res, next) => {
+  db.deleteLog(res.locals.log._id, (err) => {
+    if (err) {
+      customError(500, res.locals.methodsString, next);
+    } else {
+      res.status(204)
+      .end();
+    }
+  });
+});
 
 app.get('/api/v1/logs/:name', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {

--- a/src/api.js
+++ b/src/api.js
@@ -41,8 +41,21 @@ function bodyObjectCheck(req, res, next) {
   }
 }
 
+function genericHead(req, res, next) {
+  if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
+    res.status(200)
+    .set({
+      'Content-Type': 'application/hal+json',
+      Allow: res.locals.methodsString,
+    })
+    .end();
+  } else {
+    customError(406, res.locals.methodsString, next);
+  }
+}
+
 app.all('/api/v1', (req, res, next) => {
-  res.locals.methods = ['GET'];
+  res.locals.methods = ['HEAD', 'GET'];
   res.locals.methodsString = res.locals.methods.join(', ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
@@ -50,6 +63,8 @@ app.all('/api/v1', (req, res, next) => {
     customError(405, res.locals.methodsString, next, `You cannot ${req.method} /api/v1. Try ${res.locals.methodsString} instead.`);
   }
 });
+
+app.head('/api/v1', genericHead);
 
 app.get('/api/v1', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -74,7 +89,7 @@ app.get('/api/v1', (req, res, next) => {
 });
 
 app.all('/api/v1/users', (req, res, next) => {
-  res.locals.methods = ['GET', 'POST'];
+  res.locals.methods = ['HEAD', 'GET', 'POST'];
   res.locals.methodsString = res.locals.methods.join(', ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
@@ -82,6 +97,8 @@ app.all('/api/v1/users', (req, res, next) => {
     customError(405, res.locals.methodsString, next, `You cannot ${req.method} /api/v1/users. Try ${res.locals.methodsString} instead.`);
   }
 });
+
+app.head('/api/v1/users', genericHead);
 
 app.get('/api/v1/users', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -131,7 +148,7 @@ app.post('/api/v1/users', reqMediaCheck, jsonParser, (req, res, next) => {
 });
 
 app.all('/api/v1/users/:name', (req, res, next) => {
-  res.locals.methods = ['GET', 'PUT', 'DELETE'];
+  res.locals.methods = ['HEAD', 'GET', 'PUT', 'DELETE'];
   res.locals.methodsString = res.locals.methods.join(', ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
@@ -150,6 +167,8 @@ app.use('/api/v1/users/:name', (req, res, next) => {
     }
   });
 });
+
+app.head('/api/v1/users/:name', genericHead);
 
 app.get('/api/v1/users/:name', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -211,7 +230,7 @@ app.put('/api/v1/users/:name', (req, res) => {
 });
 
 app.all('/api/v1/messages', (req, res, next) => {
-  res.locals.methods = ['GET', 'POST'];
+  res.locals.methods = ['HEAD', 'GET', 'POST'];
   res.locals.methodsString = res.locals.methods.join(', ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
@@ -219,6 +238,8 @@ app.all('/api/v1/messages', (req, res, next) => {
     customError(405, res.locals.methodsString, next, `You cannot ${req.method} /api/v1/messages. Try ${res.locals.methodsString} instead.`);
   }
 });
+
+app.head('/api/v1/messages', genericHead);
 
 app.get('/api/v1/messages', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -276,7 +297,7 @@ app.post('/api/v1/messages', reqMediaCheck, jsonParser, (req, res, next) => {
 });
 
 app.all('/api/v1/messages/:ref_id', (req, res, next) => {
-  res.locals.methods = ['GET', 'PUT', 'DELETE'];
+  res.locals.methods = ['HEAD', 'GET', 'PUT', 'DELETE'];
   res.locals.methodsString = res.locals.methods.join(', ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
@@ -295,6 +316,8 @@ app.use('/api/v1/messages/:ref_id', (req, res, next) => {
     }
   });
 });
+
+app.head('/api/v1/messages/:ref_id', genericHead);
 
 app.get('/api/v1/messages/:ref_id', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -385,7 +408,7 @@ app.put('/api/v1/messages/:ref_id', (req, res) => {
 });
 
 app.all('/api/v1/logs', (req, res, next) => {
-  res.locals.methods = ['GET', 'POST'];
+  res.locals.methods = ['HEAD', 'GET', 'POST'];
   res.locals.methodsString = res.locals.methods.join(', ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
@@ -393,6 +416,8 @@ app.all('/api/v1/logs', (req, res, next) => {
     customError(405, res.locals.methodsString, next, `You cannot ${req.method} /api/v1/logs. Try ${res.locals.methodsString} instead.`);
   }
 });
+
+app.head('/api/v1/logs', genericHead);
 
 app.get('/api/v1/logs', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {
@@ -468,7 +493,7 @@ app.post('/api/v1/logs', reqMediaCheck, jsonParser, (req, res, next) => {
 });
 
 app.all('/api/v1/logs/:name', (req, res, next) => {
-  res.locals.methods = ['GET', 'PUT', 'DELETE'];
+  res.locals.methods = ['HEAD', 'GET', 'PUT', 'DELETE'];
   res.locals.methodsString = res.locals.methods.join(', ');
   if (res.locals.methods.indexOf(req.method) > -1) {
     next();
@@ -487,6 +512,8 @@ app.use('/api/v1/logs/:name', (req, res, next) => {
     }
   });
 });
+
+app.head('/api/v1/logs/:name', genericHead);
 
 app.get('/api/v1/logs/:name', (req, res, next) => {
   if (req.accepts(['application/hal+json', 'application/json', 'json'])) {

--- a/test/api.js
+++ b/test/api.js
@@ -45,6 +45,19 @@ function genericHEAD(endpoint) {
   });
 }
 
+function genericOPTIONS(endpoint, methods) {
+  it('should be able to respond with status code 200 and possible endpoint methods', (done) => {
+    chai.request(app)
+    .options(endpoint)
+    .end((err, res) => {
+      should.not.exist(err);
+      res.should.have.status(200);
+      res.headers.allow.should.equal(methods);
+      done();
+    });
+  });
+}
+
 function genericGET(endpoint) {
   it('should be able to respond with a body of type application/hal+json', (done) => {
     chai.request(app)
@@ -287,9 +300,13 @@ describe('API', () => {
   });
 
   describe('/api/v1', () => {
-    endpointMethods('/api/v1/', ['HEAD', 'GET']);
+    const methods = ['HEAD', 'OPTIONS', 'GET'];
+    endpointMethods('/api/v1/', methods);
     describe('HEAD', () => {
       genericHEAD('/api/v1');
+    });
+    describe('OPTIONS', () => {
+      genericOPTIONS('/api/v1', methods.join(' '));
     });
     describe('GET', () => {
       genericGET('/api/v1');
@@ -298,9 +315,13 @@ describe('API', () => {
   });
 
   describe('/api/v1/users', () => {
-    endpointMethods('/api/v1/users/', ['HEAD', 'GET', 'POST']);
+    const methods = ['HEAD', 'OPTIONS', 'GET', 'POST'];
+    endpointMethods('/api/v1/users/', methods);
     describe('HEAD', () => {
       genericHEAD('/api/v1/users');
+    });
+    describe('OPTIONS', () => {
+      genericOPTIONS('/api/v1/users', methods.join(' '));
     });
     describe('GET', () => {
       genericGET('/api/v1/users');
@@ -314,9 +335,13 @@ describe('API', () => {
   });
 
   describe('/api/v1/users/:name', () => {
-    endpointMethods(`/api/v1/users/${userNames[0]}`, ['HEAD', 'GET', 'PUT', 'DELETE']);
+    const methods = ['HEAD', 'OPTIONS', 'GET', 'PUT', 'DELETE'];
+    endpointMethods(`/api/v1/users/${userNames[0]}`, methods);
     describe('HEAD', () => {
       genericHEAD(`/api/v1/users/${userNames[0]}`);
+    });
+    describe('OPTIONS', () => {
+      genericOPTIONS(`/api/v1/users/${userNames[0]}`, methods.join(' '));
     });
     describe('GET', () => {
       badResource('/api/v1/users/');
@@ -343,9 +368,13 @@ describe('API', () => {
   });
 
   describe('/api/v1/messages', () => {
-    endpointMethods('/api/v1/messages/', ['HEAD', 'GET', 'POST']);
+    const methods = ['HEAD', 'OPTIONS', 'GET', 'POST'];
+    endpointMethods('/api/v1/messages/', methods);
     describe('HEAD', () => {
       genericHEAD('/api/v1/messages');
+    });
+    describe('OPTIONS', () => {
+      genericOPTIONS('/api/v1/messages', methods.join(' '));
     });
     describe('GET', () => {
       genericGET('/api/v1/messages');
@@ -357,9 +386,13 @@ describe('API', () => {
   });
 
   describe('/api/v1/messages/:ref_id', () => {
-    endpointMethods(`/api/v1/messages/${msgRefIds[0]}`, ['HEAD', 'GET', 'PUT', 'DELETE']);
+    const methods = ['HEAD', 'OPTIONS', 'GET', 'PUT', 'DELETE'];
+    endpointMethods(`/api/v1/messages/${msgRefIds[0]}`, methods);
     describe('HEAD', () => {
       genericHEAD(`/api/v1/messages/${msgRefIds[0]}`);
+    });
+    describe('OPTIONS', () => {
+      genericOPTIONS(`/api/v1/messages/${msgRefIds[0]}`, methods.join(' '));
     });
     describe('GET', () => {
       badResource('/api/v1/messages/');
@@ -381,9 +414,13 @@ describe('API', () => {
   });
 
   describe('/api/v1/logs', () => {
-    endpointMethods('/api/v1/logs/', ['HEAD', 'GET', 'POST']);
+    const methods = ['HEAD', 'OPTIONS', 'GET', 'POST'];
+    endpointMethods('/api/v1/logs/', methods);
     describe('HEAD', () => {
       genericHEAD('/api/v1/logs');
+    });
+    describe('OPTIONS', () => {
+      genericOPTIONS('/api/v1/logs', methods.join(' '));
     });
     describe('GET', () => {
       genericGET('/api/v1/logs');
@@ -397,9 +434,13 @@ describe('API', () => {
   });
 
   describe('/api/v1/logs/:name', () => {
-    endpointMethods(`/api/v1/logs/${logNames[0]}`, ['HEAD', 'GET', 'PUT', 'DELETE']);
+    const methods = ['HEAD', 'OPTIONS', 'GET', 'PUT', 'DELETE'];
+    endpointMethods(`/api/v1/logs/${logNames[0]}`, methods);
     describe('HEAD', () => {
       genericHEAD(`/api/v1/logs/${logNames[0]}`);
+    });
+    describe('OPTIONS', () => {
+      genericOPTIONS(`/api/v1/logs/${logNames[0]}`, methods.join(' '));
     });
     describe('GET', () => {
       badResource('/api/v1/logs/');

--- a/test/api.js
+++ b/test/api.js
@@ -23,7 +23,7 @@ function randomTestString(stringLength = 75) {
 }
 
 function genericHEAD(endpoint) {
-  it('should be able to respond with status code 200 to "Accept: application/hal+json"', (done) => {
+  it('should respond with status code 200 to "Accept: application/hal+json"', (done) => {
     chai.request(app)
     .head(endpoint)
     .set('Accept', 'application/hal+json')
@@ -46,13 +46,25 @@ function genericHEAD(endpoint) {
 }
 
 function genericOPTIONS(endpoint, methods) {
-  it('should be able to respond with status code 200 and possible endpoint methods', (done) => {
+  it('should respond with status code 200 and possible endpoint methods', (done) => {
     chai.request(app)
     .options(endpoint)
     .end((err, res) => {
       should.not.exist(err);
       res.should.have.status(200);
       res.headers.allow.should.equal(methods);
+      done();
+    });
+  });
+}
+
+function genericDELETE(endpoint) {
+  it('should respond with status code 204', (done) => {
+    chai.request(app)
+    .delete(endpoint)
+    .end((err, res) => {
+      should.not.exist(err);
+      res.should.have.status(204);
       done();
     });
   });
@@ -87,7 +99,7 @@ function genericGET(endpoint) {
       done();
     });
   });
-  it('should respond with 406 to other media types', (done) => {
+  it('should respond with 406 to other media types in request "Accept"', (done) => {
     chai.request(app)
     .get(endpoint)
     .set('Accept', 'foo')
@@ -305,9 +317,11 @@ describe('API', () => {
     describe('HEAD', () => {
       genericHEAD('/api/v1');
     });
+
     describe('OPTIONS', () => {
       genericOPTIONS('/api/v1', methods.join(' '));
     });
+
     describe('GET', () => {
       genericGET('/api/v1');
       idempotentGET('/api/v1');
@@ -320,13 +334,16 @@ describe('API', () => {
     describe('HEAD', () => {
       genericHEAD('/api/v1/users');
     });
+
     describe('OPTIONS', () => {
       genericOPTIONS('/api/v1/users', methods.join(' '));
     });
+
     describe('GET', () => {
       genericGET('/api/v1/users');
       idempotentGET('/api/v1/users');
     });
+
     describe('POST', () => {
       const body = { name: userNames[2] };
       genericPOST('/api/v1/users', body);
@@ -340,9 +357,15 @@ describe('API', () => {
     describe('HEAD', () => {
       genericHEAD(`/api/v1/users/${userNames[0]}`);
     });
+
     describe('OPTIONS', () => {
       genericOPTIONS(`/api/v1/users/${userNames[0]}`, methods.join(' '));
     });
+
+    describe('DELETE', () => {
+      genericDELETE(`/api/v1/users/${userNames[0]}`);
+    });
+
     describe('GET', () => {
       badResource('/api/v1/users/');
       genericGET(`/api/v1/users/${userNames[0]}`);
@@ -359,6 +382,7 @@ describe('API', () => {
         });
       });
     });
+
     describe('PUT', () => {
       describe('name', () => {
         const body = { name: userNames[1] };
@@ -373,13 +397,16 @@ describe('API', () => {
     describe('HEAD', () => {
       genericHEAD('/api/v1/messages');
     });
+
     describe('OPTIONS', () => {
       genericOPTIONS('/api/v1/messages', methods.join(' '));
     });
+
     describe('GET', () => {
       genericGET('/api/v1/messages');
       idempotentGET('/api/v1/messages');
     });
+
     describe('POST', () => {
       genericPOST('/api/v1/messages', { user: userNames[0], text: msgTexts[2] });
     });
@@ -391,14 +418,21 @@ describe('API', () => {
     describe('HEAD', () => {
       genericHEAD(`/api/v1/messages/${msgRefIds[0]}`);
     });
+
     describe('OPTIONS', () => {
       genericOPTIONS(`/api/v1/messages/${msgRefIds[0]}`, methods.join(' '));
     });
+
+    describe('DELETE', () => {
+      genericDELETE(`/api/v1/messages/${msgRefIds[0]}`);
+    });
+
     describe('GET', () => {
       badResource('/api/v1/messages/');
       genericGET(`/api/v1/messages/${msgRefIds[0]}`);
       idempotentGET(`/api/v1/messages/${msgRefIds[0]}`);
     });
+
     describe('PUT', () => {
       describe('user', () => {
         const body = { user: userNames[1] };
@@ -419,13 +453,16 @@ describe('API', () => {
     describe('HEAD', () => {
       genericHEAD('/api/v1/logs');
     });
+
     describe('OPTIONS', () => {
       genericOPTIONS('/api/v1/logs', methods.join(' '));
     });
+
     describe('GET', () => {
       genericGET('/api/v1/logs');
       idempotentGET('/api/v1/logs');
     });
+
     describe('POST', () => {
       const body = { users: [userNames[0], userNames[1]], messages: [msgRefIds[0], msgRefIds[1]], name: logNames[2] };
       genericPOST('/api/v1/logs', body);
@@ -439,9 +476,15 @@ describe('API', () => {
     describe('HEAD', () => {
       genericHEAD(`/api/v1/logs/${logNames[0]}`);
     });
+
     describe('OPTIONS', () => {
       genericOPTIONS(`/api/v1/logs/${logNames[0]}`, methods.join(' '));
     });
+
+    describe('DELETE', () => {
+      genericDELETE(`/api/v1/logs/${logNames[0]}`);
+    });
+
     describe('GET', () => {
       badResource('/api/v1/logs/');
       genericGET(`/api/v1/logs/${logNames[0]}`);
@@ -458,17 +501,20 @@ describe('API', () => {
         });
       });
     });
+
     describe('PUT', () => {
       describe('name', () => {
         const body = { name: logNames[2] };
         genericPUT(`/api/v1/logs/${logNames[0]}`, body);
         idempotentPUT(`/api/v1/logs/${logNames[0]}`, body);
       });
+
       describe('users', () => {
         const body = { users: [userNames[1]] };
         genericPUT(`/api/v1/logs/${logNames[0]}`, body);
         idempotentPUT(`/api/v1/logs/${logNames[0]}`, body);
       });
+
       describe('messages', () => {
         const body = { messages: [msgRefIds[1]] };
         genericPUT(`/api/v1/logs/${logNames[0]}`, body);


### PR DESCRIPTION
# What

- Add basic routes for HEAD, OPTIONS, and DELETE. All routes can take HEAD & OPTIONs. Only specific resource endpoints--e.g. /api/v1/users/:name--can take DELETE.
- Write generic tests for these methods.

# Why

DELETE is the last essential piece for client interaction with the API. HEAD & OPTIONS are less important, but are here for full coverage. 

# Test
./test/api.js